### PR TITLE
Apply API migration: rename window/control messages, update draw APIs

### DIFF
--- a/editor/editor_draw.c
+++ b/editor/editor_draw.c
@@ -441,8 +441,6 @@ draw_editor(window_t *win,
   glBindBuffer(GL_ARRAY_BUFFER, editor->vbo);
   glDisable(GL_DEPTH_TEST);
   
-  extern window_t *_focused;
-
 //  if (editor->window != active) {
 //    goto draw_player;
 //  }

--- a/editor/editor_input.c
+++ b/editor/editor_input.c
@@ -110,14 +110,13 @@ void set_selection_mode(editor_state_t *editor, int mode) {
       return;
   }
   clear_window_children(g_inspector);
-  send_message(g_inspector, kWindowMessageCreate, 0, editor);
+  send_message(g_inspector, evCreate, 0, editor);
   invalidate_window(g_inspector);
 }
 
 static void update_inspector(editor_state_t *editor, objtype_t type) {
-  extern window_t *_focused;
   winproc_t proc = NULL;
-  window_t *old_focus = _focused;
+  window_t *old_focus = g_ui_runtime.focused;
   switch (type) {
     case ObjTypeThing: proc = win_thing; break;
     case ObjTypeSector: proc = win_sector; break;
@@ -128,7 +127,7 @@ static void update_inspector(editor_state_t *editor, objtype_t type) {
   if (g_inspector->proc != proc) {
     g_inspector->proc = proc;
     clear_window_children(g_inspector);
-    send_message(g_inspector, kWindowMessageCreate, 0, editor);
+    send_message(g_inspector, evCreate, 0, editor);
     invalidate_window(g_inspector);
     set_focus(old_focus);
   }
@@ -219,17 +218,17 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
   editor_state_t *editor = game ? &game->state : NULL;
   int point = -1;
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
       ((game_t *)lparam)->state.window = win;
       return true;
-    case kWindowMessageDestroy:
+    case evDestroy:
       free_map_data(&game->map);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       draw_editor(win, &game->map, editor, &game->player);
       return true;
-    case kWindowMessageMouseMove:
+    case evMouseMove:
       track_mouse(win);
       editor->hover.type = ObjTypeNone;
       editor->hover.index = 0xFFFF;
@@ -279,11 +278,11 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
       invalidate_window(win);
       invalidate_window(g_inspector);
       return true;
-      //    case kWindowMessageWheel:
+      //    case evWheel:
       //      editor->scale *= 1.f - (int16_t)HIWORD(wparam)/50.f;
       //      invalidate_window(win);
       //      return true;
-    case kWindowMessageMouseLeave:
+    case evMouseLeave:
 //      editor->hover.point = -1;
 //      editor->hover.sector = -1;
 //      editor->hover.line = -1;
@@ -291,7 +290,7 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
       invalidate_window(win);
       invalidate_window(g_inspector);
       return true;
-    case kWindowMessageWheel: {
+    case evWheel: {
       mat4 mvp;
       vec3 world_before, world_after, delta;
       get_editor_mvp(editor, mvp);
@@ -304,7 +303,7 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
       invalidate_window(win);
       return true;
     }
-    case kWindowMessageLeftButtonUp:
+    case evLeftButtonUp:
       if (editor->move_camera == 2) {
         editor->move_camera = 1;
       } else if (editor->sel_mode == EditModeSelect) {
@@ -314,7 +313,7 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
 //        editor->move_thing = 0;
       }
       return true;
-    case kWindowMessageLeftButtonDown:
+    case evLeftButtonDown:
       if (editor->move_camera > 0) {
         editor->move_camera = 2;
         return true;
@@ -385,7 +384,7 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
           break;
       }
       return true;
-    case kWindowMessageRightButtonDown:
+    case evRightButtonDown:
       switch (editor->sel_mode) {
         case EditModeVertices:
           if (editor->drawing) {
@@ -403,7 +402,7 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
           break;
       }
       return true;
-    case kWindowMessageRightButtonUp:
+    case evRightButtonUp:
       switch (editor->sel_mode) {
         case EditModeVertices:
           if (editor->dragging && has_selection(editor->hover, ObjTypePoint)) {
@@ -417,10 +416,10 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
           return true;
       }
       return true;
-    case kWindowMessageKillFocus:
+    case evKillFocus:
       editor_reset_input(editor);
       return true;
-    case kWindowMessageKeyDown:
+    case evKeyDown:
       switch (wparam) {
         case AX_KEY_W:
         case AX_KEY_UPARROW:
@@ -479,7 +478,7 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
           return true;
       }
       break;
-    case kWindowMessageKeyUp:
+    case evKeyUp:
       if (wparam == AX_KEY_CTRL) {
         editor->move_camera = 0;
       }

--- a/editor/windows/game.c
+++ b/editor/windows/game.c
@@ -6,6 +6,8 @@
 #include <mapview/sprites.h>
 #include <mapview/console.h>
 #include <editor/editor.h>
+#include <ui/user/user.h>
+#include <ui/user/draw.h>
 
 game_t *g_game = NULL;
 
@@ -50,7 +52,7 @@ void new_map(void) {
   game_t *gm = malloc(sizeof(game_t));
   memset(gm, 0, sizeof(game_t));
   gm->last_time = (uint32_t)axGetMilliseconds();
-  show_window(create_window("New map", 0, new_frame(), NULL, win_editor, gm), true);
+  show_window(create_window("New map", 0, new_frame(), NULL, win_editor, 0, gm), true);
   init_editor(&gm->state);
   g_game = gm;
 }
@@ -78,7 +80,7 @@ void open_map(const char *mapname) {
 
   init_editor(&gm->state);
 
-  show_window(create_window(mapname, 0, new_frame(), NULL, win_editor, gm), true);
+  show_window(create_window(mapname, 0, new_frame(), NULL, win_editor, 0, gm), true);
   
   g_game = gm;
 }
@@ -204,7 +206,7 @@ void draw_dungeon(window_t const *win, bool draw_pixel) {
   game_t *game = win->userdata;
   
   if (game->map.num_vertices == 0) {
-    fill_rect(get_sys_color(kColorWindowBg), 0, 0, win->frame.w, win->frame.h);
+    fill_rect(get_sys_color(brWindowBg), R(0, 0, win->frame.w, win->frame.h));
     return;
   }
 
@@ -265,7 +267,7 @@ void draw_dungeon(window_t const *win, bool draw_pixel) {
   set_projection(0, 0, win->frame.w, win->frame.h);
   
 //  result_t win_perf(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
-//  win_perf((window_t*)win, kWindowMessagePaint, 0, NULL);
+//  win_perf((window_t*)win, evPaint, 0, NULL);
   
 //  mapside_texture_t const *tex1 = get_texture(get_selected_texture());
 //  mapside_texture_t const *tex2 = get_flat_texture(get_selected_flat_texture());
@@ -340,33 +342,31 @@ result_t win_editor(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
 result_t win_game(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   static bool alt = false;
   static bool moved = false;
-  extern window_t *_focused;
-  extern window_t *_captured;
   game_t *game = win->userdata;
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
-      create_window("FPS", 0, MAKERECT(0, 0, 128, 64), win, win_perf, NULL);
+      create_window("FPS", 0, MAKERECT(0, 0, 128, 64), win, win_perf, 0, NULL);
       return true;
-    case kWindowMessageDestroy:
+    case evDestroy:
       free_map_data(&game->map);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       game_tick(game);
       draw_dungeon(win, moved);
-      if (_focused == win) {
-        post_message(win, kWindowMessagePaint, wparam, lparam);
+      if (g_ui_runtime.focused == win) {
+        post_message(win, evPaint, wparam, lparam);
       }
       moved = false;
       return false;
   }
 
-  if (_captured == win) {
+  if (g_ui_runtime.captured == win) {
     switch (msg) {
-      case kWindowMessageKillFocus:
+      case evKillFocus:
         g_relative_mouse_mode = false;
         return true;
-      case kWindowMessageKeyDown:
+      case evKeyDown:
         switch (wparam) {
           case AX_KEY_ESCAPE:
             g_relative_mouse_mode = false;
@@ -419,7 +419,7 @@ result_t win_game(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
             return true;
         }
         return true;
-      case kWindowMessageKeyUp:
+      case evKeyUp:
         switch (wparam) {
           case AX_KEY_W:
           case AX_KEY_UPARROW:
@@ -444,10 +444,10 @@ result_t win_game(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
             break;
         }
         return true;
-//      case kWindowMessageWheel:
+//      case evWheel:
 //        handle_scroll((int[]){(int16_t)LOWORD(wparam), (int16_t)HIWORD(wparam)}, &game->map);
 //        return true;
-      case kWindowMessageMouseMove:
+      case evMouseMove:
         moved = true;
         game->player.angle += ((int16_t)LOWORD((intptr_t)lparam)) * sensitivity_x;
         game->player.pitch -= ((int16_t)HIWORD((intptr_t)lparam)) * sensitivity_y;
@@ -458,17 +458,17 @@ result_t win_game(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         if (game->player.pitch > 89.0f) game->player.pitch = 89.0f;
         if (game->player.pitch < -89.0f) game->player.pitch = -89.0f;
         return true;
-      case kWindowMessageLeftButtonUp:
+      case evLeftButtonUp:
         paint_face(&game->map, (ui_get_mod_state() & AX_MOD_ALT) != 0);
         return true;
-      case kWindowMessageJoyButtonDown:
+      case evJoyButtonDown:
         if (wparam == 0) {
           paint_face(&game->map, false);
         } else if (wparam == 1) {
           paint_face(&game->map, true);
         }
         return true;
-      case kWindowMessageJoyAxisMotion:
+      case evJoyAxisMotion:
         switch (LOWORD(wparam)) {
           case 0: game->player.strafe_move = ((int16_t)HIWORD(wparam))/(float)0x8000; break;
           case 1: game->player.forward_move = -((int16_t)HIWORD(wparam))/(float)0x8000; break;
@@ -477,15 +477,15 @@ result_t win_game(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         }
         return true;
     }
-  } else if (_focused == win) {
+  } else if (g_ui_runtime.focused == win) {
     switch (msg) {
-      case kWindowMessageLeftButtonUp:
+      case evLeftButtonUp:
         if (!g_relative_mouse_mode) {
           set_capture(win);
           g_relative_mouse_mode = true;
         }
         return true;
-      case kWindowMessageKeyDown:
+      case evKeyDown:
         switch (wparam) {
           case AX_KEY_TAB:
             set_capture(NULL);

--- a/editor/windows/inspector/insp_line.c
+++ b/editor/windows/inspector/insp_line.c
@@ -77,12 +77,12 @@ result_t win_line(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   editor_state_t *editor = get_editor();
   maplinedef_t *line = selected_line(g_game);
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
       g_inspector = win;
       load_window_children(win, line_layout);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       if (line) {
         set_window_item_text(win, ID_LINE_IDENT, "%d", line - g_game->map.linedefs);
         set_window_item_text(win, ID_LINE_TYPE, "%d", line->special);
@@ -110,10 +110,10 @@ result_t win_line(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         }
       }
       return false;
-    case kWindowMessageCommand:
+    case evCommand:
       if (line) {
 #define SET_OFFSET(ID, SIDE, OFFSET) \
-        if (wparam == MAKEDWORD(ID, kEditNotificationUpdate) && line->sidenum[SIDE] != 0xFFFF && g_game) { \
+        if (wparam == MAKEDWORD(ID, edUpdate) && line->sidenum[SIDE] != 0xFFFF && g_game) { \
           mapsidedef_t *side = &g_game->map.sidedefs[line->sidenum[SIDE]]; \
           side->OFFSET = atoi(((window_t *)lparam)->title); \
           build_wall_vertex_buffer(&g_game->map); \

--- a/editor/windows/inspector/insp_sector.c
+++ b/editor/windows/inspector/insp_sector.c
@@ -51,11 +51,11 @@ mapsector_t *selected_sector(game_t *game) {
 //  send_message(cb, CB_SETCURSEL, 2, NULL);
 //}
 
-static toolbar_button_t but[] = {
-  { EdIcon16Select, EditModeSelect },
-  { EdIcon16Points, EditModeVertices },
-  { EdIcon16Things, EditModeThings },
-  { EdIcon16Sounds, EditModeSounds },
+static toolbar_item_t but[] = {
+  { TOOLBAR_ITEM_BUTTON, EditModeSelect,   EdIcon16Select, 0, 0, NULL },
+  { TOOLBAR_ITEM_BUTTON, EditModeVertices, EdIcon16Points, 0, 0, NULL },
+  { TOOLBAR_ITEM_BUTTON, EditModeThings,   EdIcon16Things, 0, 0, NULL },
+  { TOOLBAR_ITEM_BUTTON, EditModeSounds,   EdIcon16Sounds, 0, 0, NULL },
 };
 
 void set_selection_mode(editor_state_t *editor, int mode);
@@ -63,18 +63,15 @@ void set_selection_mode(editor_state_t *editor, int mode);
 result_t win_dummy(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   editor_state_t *editor = get_editor();
   switch (msg) {
-    case kWindowMessageCreate:
-      send_message(win, kToolBarMessageAddButtons, sizeof(but)/sizeof(*but), but);      
+    case evCreate:
+      send_message(win, tbSetItems, sizeof(but)/sizeof(*but), but);      
       return true;
-    case kWindowMessagePaint:
-      draw_text_small("Nothing selected", 5, 5, get_sys_color(kColorDarkEdge));
-      draw_text_small("Nothing selected", 4, 4, get_sys_color(kColorTextNormal));
+    case evPaint:
+      draw_text_small("Nothing selected", 5, 5, get_sys_color(brDarkEdge));
+      draw_text_small("Nothing selected", 4, 4, get_sys_color(brTextNormal));
       return true;
-    case kToolBarMessageButtonClick:
-      for (int i = 0; i < win->num_toolbar_buttons; i++) {
-        toolbar_button_t *but = &win->toolbar_buttons[i];
-        but->active = (but->ident == wparam);
-      }
+    case tbButtonClick:
+      send_message(win, tbSetActiveButton, wparam, NULL);
       set_selection_mode(editor, wparam);
       invalidate_window(win);
       return true;
@@ -87,13 +84,13 @@ result_t win_sector(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
   editor_state_t *editor = get_editor();
   mapsector_t *sector = selected_sector(g_game);
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
       g_inspector = win;
       load_window_children(win, sector_layout);
 //      init_combobox(get_window_item(win, ID_TEST_COMBOBOX));
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       if (sector) {
         set_window_item_text(win, ID_SECTOR_IDENT, "%d", sector - g_game->map.sectors);
         set_window_item_text(win, ID_SECTOR_LIGHT_LEVEL, "%d", sector->lightlevel);
@@ -103,16 +100,16 @@ result_t win_sector(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
         set_window_item_text(win, ID_SECTOR_CEILING_IMAGE, sector->ceilingpic);
       }
       return false;
-    case kWindowMessageCommand:
+    case evCommand:
       if (sector) {
         switch (wparam) {
-          case MAKEDWORD(ID_SECTOR_LIGHT_LEVEL, kEditNotificationUpdate):
+          case MAKEDWORD(ID_SECTOR_LIGHT_LEVEL, edUpdate):
             sector->lightlevel = atoi(((window_t *)lparam)->title);
             break;
-          case MAKEDWORD(ID_SECTOR_FLOOR_HEIGHT, kEditNotificationUpdate):
+          case MAKEDWORD(ID_SECTOR_FLOOR_HEIGHT, edUpdate):
             sector->floorheight = atoi(((window_t *)lparam)->title);
             break;
-          case MAKEDWORD(ID_SECTOR_CEILING_HEIGHT, kEditNotificationUpdate):
+          case MAKEDWORD(ID_SECTOR_CEILING_HEIGHT, edUpdate):
             sector->ceilingheight = atoi(((window_t *)lparam)->title);
             break;
         }

--- a/editor/windows/inspector/insp_thing.c
+++ b/editor/windows/inspector/insp_thing.c
@@ -83,13 +83,8 @@ mapthing_t *selected_thing(game_t *game) {
 
 result_t win_things(window_t *, uint32_t, uint32_t, void *);
 
-rect_t shrink_rect(rect_t const *rect) {
-  return (rect_t){rect->x+8,rect->y+8,THING_SIZE*3,rect->h-16};
-}
-
 uint16_t select_thing_type(window_t *owner) {
-  rect_t rect = shrink_rect(&owner->frame);
-  return show_dialog("Things", &rect, owner, win_things, NULL);
+  return show_dialog("Things", THING_SIZE*3, owner->frame.h-16, owner, win_things, NULL);
 }
 
 result_t win_dummy(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
@@ -99,12 +94,12 @@ result_t win_thing(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   mapthing_t *thing = selected_thing(g_game);
   uint16_t tmp;
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
       g_inspector = win;
       load_window_children(win, thing_layout);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       if (thing) {
         sprite_t *spr = get_thing_sprite_name(thing->type, 0);
         set_window_item_text(win, ID_THING_SPRITE, spr?spr->name:"");
@@ -115,15 +110,15 @@ result_t win_thing(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         for (int i = 0; i < sizeof(thing_checkboxes)/sizeof(*thing_checkboxes); i++) {
           window_t *checkbox = get_window_item(win, thing_checkboxes[i]);
           uint32_t value = thing->options&(1<<i);
-          send_message(checkbox, kButtonMessageSetCheck, value, NULL);
+          send_message(checkbox, btnSetCheck, value, NULL);
         }
       }
       return false;
-    case kWindowMessageCommand:
+    case evCommand:
       if (thing) {
         for (int i = 0; i < sizeof(thing_checkboxes)/sizeof(*thing_checkboxes); i++) {
-          if (wparam == MAKEDWORD(thing_checkboxes[i], kButtonNotificationClicked)) {
-            if (send_message(lparam, kButtonMessageGetCheck, 0, NULL)) {
+          if (wparam == MAKEDWORD(thing_checkboxes[i], btnClicked)) {
+            if (send_message(lparam, btnGetCheck, 0, NULL)) {
               thing->options |= 1 << i;
             } else {
               thing->options &= ~(1 << i);
@@ -131,19 +126,19 @@ result_t win_thing(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
           }
         }
         switch (wparam) {
-          case MAKEDWORD(ID_THING_POS_X, kEditNotificationUpdate):
+          case MAKEDWORD(ID_THING_POS_X, edUpdate):
             thing->x = atoi(((window_t *)lparam)->title);
             invalidate_window(editor->window);
             break;
-          case MAKEDWORD(ID_THING_POS_Y, kEditNotificationUpdate):
+          case MAKEDWORD(ID_THING_POS_Y, edUpdate):
             thing->y = atoi(((window_t *)lparam)->title);
             invalidate_window(editor->window);
             break;
-          case MAKEDWORD(ID_THING_ANGLE, kEditNotificationUpdate):
+          case MAKEDWORD(ID_THING_ANGLE, edUpdate):
             thing->angle = atoi(((window_t *)lparam)->title);
             invalidate_window(editor->window);
             break;
-          case MAKEDWORD(ID_THING_SPRITE, kButtonNotificationClicked):
+          case MAKEDWORD(ID_THING_SPRITE, btnClicked):
             if ((tmp = select_thing_type(win)) != 0xFFFF) {
               thing->type = tmp;
               invalidate_window(editor->window);

--- a/editor/windows/inspector/insp_vertex.c
+++ b/editor/windows/inspector/insp_vertex.c
@@ -30,25 +30,25 @@ result_t win_vertex(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
   editor_state_t *editor = get_editor();
   mapvertex_t *point = selected_vertex(g_game);
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
       g_inspector = win;
       load_window_children(win, vertex_layout);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       if (point) {
         set_window_item_text(win, ID_VERTEX_ID, "%d", point - g_game->map.vertices);
         set_window_item_text(win, ID_VERTEX_POS_X, "%d", point->x);
         set_window_item_text(win, ID_VERTEX_POS_Y, "%d", point->y);
       }
       return false;
-    case kWindowMessageCommand:
+    case evCommand:
       if (point) {
-        if (wparam == MAKEDWORD(ID_VERTEX_POS_X, kEditNotificationUpdate)) {
+        if (wparam == MAKEDWORD(ID_VERTEX_POS_X, edUpdate)) {
           point->x = atoi(((window_t *)lparam)->title);
           invalidate_window(editor->window);
         }
-        if (wparam == MAKEDWORD(ID_VERTEX_POS_Y, kEditNotificationUpdate)) {
+        if (wparam == MAKEDWORD(ID_VERTEX_POS_Y, edUpdate)) {
           point->y = atoi(((window_t *)lparam)->title);
           invalidate_window(editor->window);
         }

--- a/editor/windows/perfcounter.c
+++ b/editor/windows/perfcounter.c
@@ -13,7 +13,7 @@ static struct {
 
 result_t win_perf(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   switch (msg) {
-    case kWindowMessagePaint: {
+    case evPaint: {
       uint32_t ticks = (uint32_t)axGetMilliseconds();
       fps_state.ticks[fps_state.counter++&63] = ticks - fps_state.last_fps_update;
       fps_state.last_fps_update = ticks;

--- a/editor/windows/project.c
+++ b/editor/windows/project.c
@@ -21,28 +21,28 @@ void collect_proc(const char *name, void *parm) {
 result_t win_project(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   items_t const *items = win->userdata;
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
 			win->userdata = malloc(sizeof(items_t));
 			find_all_maps(collect_proc, win);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       for (int i = 0, y = 0; i < items->num_items; i++, y += BUTTON_HEIGHT) {
         if (win->cursor_pos == i) {
-          fill_rect(get_sys_color(kColorTextNormal), 0, y, win->frame.w, BUTTON_HEIGHT);
-          draw_text_small(items->items[i], 4, y+3, get_sys_color(kColorWindowBg));
+          fill_rect(get_sys_color(brTextNormal), R(0, y, win->frame.w, BUTTON_HEIGHT));
+          draw_text_small(items->items[i], 4, y+3, get_sys_color(brWindowBg));
         } else {
-          draw_text_small(items->items[i], 4, y+3, get_sys_color(kColorTextNormal));
+          draw_text_small(items->items[i], 4, y+3, get_sys_color(brTextNormal));
         }
       }
       return true;
-    case kWindowMessageLeftButtonUp:
+    case evLeftButtonUp:
       win->cursor_pos = HIWORD(wparam)/BUTTON_HEIGHT;
       if (win->cursor_pos < items->num_items) {
         open_map(items->items[win->cursor_pos]);
       }
       invalidate_window(win);
       return true;
-    case kWindowMessageKeyDown:
+    case evKeyDown:
       if (wparam == AX_KEY_UPARROW && win->cursor_pos > 0) {
         win->cursor_pos--;
         invalidate_window(win);

--- a/editor/windows/project.c
+++ b/editor/windows/project.c
@@ -22,7 +22,10 @@ result_t win_project(window_t *win, uint32_t msg, uint32_t wparam, void *lparam)
   items_t const *items = win->userdata;
   switch (msg) {
     case evCreate:
-			win->userdata = malloc(sizeof(items_t));
+      win->userdata = calloc(1, sizeof(items_t));
+      if (!win->userdata) {
+        return false;
+      }
 			find_all_maps(collect_proc, win);
       return true;
     case evPaint:

--- a/editor/windows/sprite.c
+++ b/editor/windows/sprite.c
@@ -13,7 +13,6 @@
 extern sprite_t *find_sprite(const char *name);
 extern mapside_texture_t const *get_flat_texture(const char *name);
 extern mapside_texture_t const *get_texture(const char *name);
-extern window_t *_focused;
 
 // Helper function to fit sprite in target rect
 rect_t fit_sprite(sprite_t const *spr, rect_t const *target) {
@@ -32,25 +31,24 @@ result_t win_sprite(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
   sprite_t const *spr;
   mapside_texture_t const *tex;
   switch (msg) {
-    case kWindowMessagePaint:
-      fill_rect(_focused == win ? get_sys_color(kColorFocusRing) : get_sys_color(kColorWindowBg), win->frame.x-2, win->frame.y-2, win->frame.w+4, win->frame.h+4);
+    case evPaint:
+      fill_rect(g_ui_runtime.focused == win ? get_sys_color(brFocusRing) : get_sys_color(brWindowBg), R(win->frame.x-2, win->frame.y-2, win->frame.w+4, win->frame.h+4));
       draw_button(&win->frame, 1, 1, true);
       if (!*win->title) return false;
       if ((spr = find_sprite(win->title))) {
         rect_t r = fit_sprite(spr, &win->frame);
-        draw_rect(spr->texture, r.x, r.y, r.w, r.h);
+        draw_rect(spr->texture, &r);
       } else if ((tex = get_flat_texture(win->title))||(tex = get_texture(win->title))) {
         float scale = fminf(1, fminf(((float)win->frame.w) / tex->width,
                                      ((float)win->frame.h) / tex->height));
-        draw_rect(tex->texture,
-                  win->frame.x+(win->frame.w-tex->width*scale)/2,
+        draw_rect(tex->texture, R(win->frame.x+(win->frame.w-tex->width*scale)/2,
                   win->frame.y+(win->frame.h-tex->height*scale)/2,
                   tex->width * scale,
-                  tex->height * scale);
+                  tex->height * scale));
       }
       return true;
-    case kWindowMessageLeftButtonUp:
-      send_message(win->parent, kWindowMessageCommand, MAKEDWORD(win->id, kButtonNotificationClicked), NULL);
+    case evLeftButtonUp:
+      send_message(win->parent, evCommand, MAKEDWORD(win->id, btnClicked), NULL);
       return true;
   }
   return false;

--- a/editor/windows/statbar.c
+++ b/editor/windows/statbar.c
@@ -3,7 +3,7 @@
 
 result_t win_statbar(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
 #ifdef HEXEN
       load_sprite("H2BAR");
       load_sprite("H2TOP");
@@ -14,7 +14,7 @@ result_t win_statbar(window_t *win, uint32_t msg, uint32_t wparam, void *lparam)
       load_sprite("STBAR");
 #endif
       break;
-    case kWindowMessagePaint: {
+    case evPaint: {
 #ifdef HEXEN
       sprite_t* STBAR = find_sprite("H2BAR");
       if (STBAR) {

--- a/editor/windows/texatlas.c
+++ b/editor/windows/texatlas.c
@@ -210,7 +210,7 @@ void draw_texture_layout(texture_layout_t* layout, mapside_texture_t* textures, 
     mapside_texture_t* tex = &textures[entry->texture_idx];
     
     // Draw the texture according to its position in the layout
-    draw_rect(tex->texture, entry->x, entry->y, tex->width * scale, tex->height * scale);
+    draw_rect(tex->texture, R(entry->x, entry->y, tex->width * scale, tex->height * scale));
   }
 }
 
@@ -235,15 +235,15 @@ void draw_texture_layout_with_selection(texture_layout_t* layout,
     texture_layout_entry_t* entry = &layout->entries[i];
     mapside_texture_t* tex = &textures[entry->texture_idx];
     // Draw the texture
-    draw_rect(tex->texture, entry->x * scale, entry->y * scale, tex->width * scale, tex->height * scale);
-    draw_rect_ex(black_tex, entry->x * scale, entry->y * scale, tex->width * scale, tex->height * scale, true, 1);
+    draw_rect(tex->texture, R(entry->x * scale, entry->y * scale, tex->width * scale, tex->height * scale));
+    draw_rect_ex(black_tex, R(entry->x * scale, entry->y * scale, tex->width * scale, tex->height * scale), true, 1);
   }
   
   for (int i = 0; i < layout->num_entries; i++) {
     texture_layout_entry_t* entry = &layout->entries[i];
     mapside_texture_t* tex = &textures[entry->texture_idx];
     if (!strncmp(tex->name, selected_texture, sizeof(texname_t))) {
-      draw_rect_ex(selection_tex, entry->x * scale, entry->y * scale, tex->width * scale, tex->height * scale, true, 1);
+      draw_rect_ex(selection_tex, R(entry->x * scale, entry->y * scale, tex->width * scale, tex->height * scale), true, 1);
     }
   }
 }
@@ -362,11 +362,11 @@ typedef struct {
 result_t win_image(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   mapside_texture_t *tex = win->userdata;
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->userdata = lparam;
       return true;
-    case kWindowMessagePaint:
-      draw_rect(tex ? tex->texture : 1, win->frame.x, win->frame.y, win->frame.w, win->frame.h);
+    case evPaint:
+      draw_rect(tex ? tex->texture : 1, R(win->frame.x, win->frame.y, win->frame.w, win->frame.h));
       return true;
   }
   return false;
@@ -375,21 +375,21 @@ result_t win_image(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
 result_t win_textures(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
   window_udata_t *udata = win->userdata;
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       udata = malloc(sizeof(window_udata_t));
       udata->cache = lparam;
       udata->layout = layout(udata->cache->num_textures, win->frame.w / SCALE, get_texture_size, udata->cache->textures);
       win->userdata = udata;
 //      create_window("Image", 0, MAKERECT(10, 10, 30, 30), win, win_image, &udata->cache->textures[0]);
       return true;
-    case kWindowMessageResize:
+    case evResize:
       free(udata->layout);
       udata->layout = layout(udata->cache->num_textures, win->frame.w / SCALE, get_texture_size, udata->cache->textures);
       return true;
-    case kWindowMessagePaint:
+    case evPaint:
       draw_texture_layout_with_selection(udata->layout, udata->cache->textures, udata->cache->selected, SCALE);
       return false;
-    case kWindowMessageLeftButtonUp: {
+    case evLeftButtonUp: {
       int texture_idx =
       get_texture_at_point(udata->layout, LOWORD(wparam) / SCALE, HIWORD(wparam) / SCALE);
       if (texture_idx >= 0) {

--- a/editor/windows/things.c
+++ b/editor/windows/things.c
@@ -33,22 +33,18 @@ result_t win_things(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
   extern char *sprnames[NUMSPRITES];
 //  editor_state_t *editor = get_editor();
   switch (msg) {
-    case kWindowMessageCreate:
+    case evCreate:
       win->flags |= WINDOW_TOOLBAR;
       win->userdata2 = lparam;
-//      win->userdata = layout(NUM_THINGS, win->frame.w, get_mobj_size, win);
     {
-      toolbar_button_t but[8]={0};
+      toolbar_item_t but[8];
       for (int i = 0; i < 8; i++) {
-        but[i].icon = 16+i;
-        but[i].ident = i;
-        but[i].active = win->cursor_pos == i;
+        but[i] = (toolbar_item_t){ TOOLBAR_ITEM_BUTTON, i, 16+i, 0, 0, NULL };
       }
-      send_message(win, kToolBarMessageAddButtons, sizeof(but)/sizeof(*but), but);
+      send_message(win, tbSetItems, 8, but);
     }
-//      send_message(win, kToolBarMessageAddButtons, sizeof(but)/sizeof(*but), but);
       break;
-    case kWindowMessagePaint:
+    case evPaint:
       for (int i = 0, j = 0; i < NUM_THINGS; i++) {
         sprite_t *spr = ed_things[i].sprite ? find_sprite(ed_things[i].sprite) : NULL;
         if (spr && ed_things[i].code1 == ed_thinggroups[win->cursor_pos].code) {
@@ -57,16 +53,16 @@ result_t win_things(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
           uint16_t y = (j / n) * (THING_SIZE+THING_LABEL_HEIGHT);
           uint16_t tx = x + (THING_SIZE-strwidth(ed_things[i].sprite))/2;
           rect_t r = fit_sprite(spr, &(rect_t){ x, y, THING_SIZE, THING_SIZE });
-          draw_rect(spr->texture, r.x, r.y, r.w, r.h);
-          draw_text_small(ed_things[i].sprite, tx, y + THING_SIZE+4, get_sys_color(kColorTextNormal));
+          draw_rect(spr->texture, &r);
+          draw_text_small(ed_things[i].sprite, tx, y + THING_SIZE+4, get_sys_color(brTextNormal));
           j++;
         }
       }
       break;
-    case kWindowMessageResize:
+    case evResize:
       invalidate_window(win);
       return true;
-    case kWindowMessageLeftButtonUp:
+    case evLeftButtonUp:
       for (int i = 0, j = 0; i < NUM_THINGS; i++) {
         sprite_t *spr = ed_things[i].sprite ? find_sprite(ed_things[i].sprite) : NULL;
         if (spr && ed_things[i].code1 == ed_thinggroups[win->cursor_pos].code) {
@@ -84,12 +80,10 @@ result_t win_things(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
         }
       }
       return true;
-    case kToolBarMessageButtonClick:
+    case tbButtonClick:
       free(win->userdata);
       win->cursor_pos = wparam;
-      for (int i = 0; i < win->num_toolbar_buttons; i++) {
-        win->toolbar_buttons[i].active = wparam == i;
-      }
+      send_message(win, tbSetActiveButton, wparam, NULL);
       invalidate_window(win);
       return true;
   }

--- a/editor/windows/things.c
+++ b/editor/windows/things.c
@@ -81,7 +81,6 @@ result_t win_things(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
       }
       return true;
     case tbButtonClick:
-      free(win->userdata);
       win->cursor_pos = wparam;
       send_message(win, tbSetActiveButton, wparam, NULL);
       invalidate_window(win);

--- a/mapview/gamefont.c
+++ b/mapview/gamefont.c
@@ -3,6 +3,7 @@
 
 #include <mapview/gl_compat.h>
 #include <ui/user/rect.h>
+#include <ui/user/draw.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -157,7 +158,7 @@ void draw_text_gl3(const char* text, int x, int y, float alpha) {
     // Advance cursor
     if (c >= 32 && c > 0) {
       // Use character width if available, otherwise use default
-      int char_width = gamefont_state.font[c].width;
+      int char_width = gamefont_state.font[(unsigned char)c].width;
       cursor_x += (char_width > 0 ? char_width : CONSOLE_FONT_WIDTH);
     } else {
       cursor_x += CONSOLE_FONT_WIDTH;  // Default width for unsupported chars
@@ -186,7 +187,7 @@ int get_text_width(const char* text) {
     // Advance cursor
     if (c >= 32 && c > 0) {
       // Use character width if available, otherwise use default
-      int char_width = gamefont_state.font[c].width;
+      int char_width = gamefont_state.font[(unsigned char)c].width;
       cursor_x += (char_width > 0 ? char_width : CONSOLE_FONT_WIDTH);
     } else {
       cursor_x += CONSOLE_FONT_WIDTH;  // Default width for unsupported chars

--- a/mapview/gamefont.c
+++ b/mapview/gamefont.c
@@ -2,6 +2,7 @@
 // Moved from ui/user/text.c to keep game-specific code in mapview
 
 #include <mapview/gl_compat.h>
+#include <ui/user/rect.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -35,7 +36,6 @@ static const char* FONT_LUMPS_PREFIX = "STCFN";
 #endif
 
 // Forward declarations for external functions
-extern void draw_rect(int tex, int x, int y, int w, int h);
 extern GLuint white_tex;
 
 // Forward declarations for WAD file functions
@@ -123,14 +123,14 @@ static void draw_char_gl3(char c, int x, int y, float alpha) {
   if (char_code < 0 || char_code >= 128 || gamefont_state.font[char_code].texture == 0) {
     // Fallback for unsupported characters - draw a solid rectangle
     if (c != ' ') {  // Skip spaces
-      draw_rect(white_tex, x, y, CONSOLE_FONT_WIDTH, CONSOLE_FONT_HEIGHT);
+      draw_rect(white_tex, R(x, y, CONSOLE_FONT_WIDTH, CONSOLE_FONT_HEIGHT));
     }
     return;
   }
   
   font_char_t* ch = &gamefont_state.font[char_code];
   
-  draw_rect(ch->texture, x - gamefont_state.font[char_code].x, y - gamefont_state.font[char_code].y, ch->width, ch->height);
+  draw_rect(ch->texture, R(x - gamefont_state.font[char_code].x, y - gamefont_state.font[char_code].y, ch->width, ch->height));
 }
 
 // Draw text string using GL3 with DOOM/Hexen font

--- a/mapview/main.c
+++ b/mapview/main.c
@@ -4,6 +4,7 @@
 #include <editor/editor.h>
 #include <mapview/gamefont.h>
 #include <ui/kernel/kernel.h>
+#include <ui/gem_magic.h>
 
 #define SCREEN_WIDTH 720
 #define SCREEN_HEIGHT 480
@@ -12,8 +13,6 @@ void init_floor_shader(void);
 void init_sky_geometry(void);
 bool init_radial_menu(void);
 
-//result_t win_desktop(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
-//result_t win_tray(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
 result_t win_statbar(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
 result_t win_console(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
 result_t win_game(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
@@ -25,65 +24,34 @@ result_t win_dummy(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
 
 window_t *g_inspector = NULL;
 
-void init_windows(void) {
-  //  create_window("FPS", WINDOW_NOTITLE|WINDOW_TRANSPARENT, MAKERECT(0, 0, 128, 64), NULL, win_perf, NULL);
-  //  create_window("Statbar", WINDOW_NOTITLE|WINDOW_TRANSPARENT, MAKERECT((ui_get_system_metrics(kSystemMetricScreenWidth)-VGA_WIDTH)/2, (ui_get_system_metrics(kSystemMetricScreenHeight)-VGA_HEGHT), VGA_WIDTH, VGA_HEGHT), NULL, win_statbar, NULL);
-  //  create_window("Console", 0, MAKERECT(32, 32, 512, 256), NULL, win_console, NULL);
-//  create_window("Game", WINDOW_NOFILL, MAKERECT(380, 128, 320, 320), NULL, win_game, NULL);
-  show_window(create_window("Things", WINDOW_VSCROLL, MAKERECT(8, 96, THING_SIZE*3, 256), NULL, win_things, NULL), true);
-  show_window(create_window("Project", WINDOW_VSCROLL, MAKERECT(4, 20, 128, 256), NULL, win_project, NULL), true);
-  //  create_window("Mode", 0, MAKERECT(200, 20, 320, 20), NULL, win_editmode, NULL);
-//  create_window("Inspector", 0, MAKERECT(200, 20, 150, 300), NULL, win_sector, NULL);
-  
-  g_inspector = create_window("Inspector", WINDOW_TOOLBAR, MAKERECT(ui_get_system_metrics(kSystemMetricScreenWidth)-200, 40, 150, 300), NULL, win_dummy, NULL);
+static void init_windows(hinstance_t hinstance) {
+  show_window(create_window("Things", WINDOW_VSCROLL, MAKERECT(8, 96, THING_SIZE*3, 256), NULL, win_things, hinstance, NULL), true);
+  show_window(create_window("Project", WINDOW_VSCROLL, MAKERECT(4, 20, 128, 256), NULL, win_project, hinstance, NULL), true);
+  g_inspector = create_window("Inspector", WINDOW_TOOLBAR, MAKERECT(ui_get_system_metrics(kSystemMetricScreenWidth)-200, 40, 150, 300), NULL, win_dummy, hinstance, NULL);
   show_window(g_inspector, true);
 }
 
-int main(int argc, char* argv[]) {
+bool gem_init(int argc, char *argv[], hinstance_t hinstance) {
   if (argc < 2) {
-    printf("Usage: %s <wad_file>\n", argv[0]);
-    return 1;
+    printf("Usage: doom-ed <wad_file>\n");
+    return false;
   }
-  
-  const char* filename = argv[1];
+
+  const char *filename = argv[1];
 
   if (!init_wad(filename)) {
     printf("Error: Could not open file %s\n", filename);
-    return 1;
+    return false;
   }
 
-//  MAP29  The Living End  ~1300 linedefs, ~1900 sidedefs, ~1100 vertices
-//  MAP15  Industrial Zone  Also very large, very open with many secrets
-//  MAP14  The Inmost Dens  Highly detailed architecture
-  
-//  E2M5 – The Crater: vertical layers, lava pit puzzle, lots of atmosphere.
-//  E3M1 – The Storehouse: crazy use of crushers, secrets, and teleport traps.
-//  E4M4 – The Halls of Fear: shows how moody lighting and vertical loops can go a long way.
-  
-  // Load E1M1 map
-  
   if (!cache_lump("PLAYPAL")) {
     printf("Error: Required lump not found (PLAYPAL)\n");
-    return 0;
+    return false;
   }
   extern palette_entry_t *palette;
   palette = cache_lump("PLAYPAL");
-  
-  // Print map info
-  // Initialize window and OpenGL context
-  if (!ui_init_graphics(UI_INIT_DESKTOP|UI_INIT_TRAY,
-                        "DOOM Wireframe Renderer",
-                        SCREEN_WIDTH, SCREEN_HEIGHT))
-  {
-    return 1;
-  }
-  
-  // Initialize joystick support through UI layer
-  // Note: Joystick initialization is now handled by the UI layer
-  // via the platform/joystick backend (no longer SDL-specific)
+
   ui_joystick_init();
-  
-  // Initialize resources
   init_resources();
   init_floor_shader();
   init_sky_geometry();
@@ -93,32 +61,19 @@ int main(int argc, char* argv[]) {
   init_sprites();
   init_things();
   init_intermission();
-  init_windows();
-  
+  init_windows(hinstance);
+
   allocate_mapside_textures();
   allocate_flat_textures();
 
-//  new_map();
   open_map("MAP01");
-  
-//  bool running = true;
-  // Main game loop
-  while (ui_is_running()) {
-    ui_event_t event;
-    while (get_message(&event)) {
-//      if (event.type == SDL_QUIT) {
-//        running = false;
-//      }
-      dispatch_message(&event);
-    }
-    repost_messages();
-  }
-
-  shutdown_wad();
-  
-  ui_joystick_shutdown();
-  
-  ui_shutdown_graphics();
-  
-  return 0;
+  return true;
 }
+
+void gem_shutdown(void) {
+  shutdown_wad();
+  ui_joystick_shutdown();
+}
+
+GEM_STANDALONE_MAIN("DOOM Wireframe Renderer", UI_INIT_DESKTOP|UI_INIT_TRAY,
+                    SCREEN_WIDTH, SCREEN_HEIGHT, NULL, NULL)

--- a/mapview/map.h
+++ b/mapview/map.h
@@ -382,8 +382,6 @@ typedef struct {
 
 struct window_s;
 
-typedef struct toolbar_button_s toolbar_button_t;
-
 void clear_window_children(window_t *win);
 void load_window_children(window_t *win, windef_t const *def);
 int send_message(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
@@ -402,7 +400,7 @@ void dispatch_message(ui_event_t *evt);
 void repost_messages(void);
 bool is_window(window_t *win);
 void end_dialog(window_t *win, uint32_t code);
-uint32_t show_dialog(char const *, const rect_t*, struct window_s *, winproc_t, void *param);
+uint32_t show_dialog(char const *, int, int, struct window_s *, winproc_t, void *param);
 
 extern window_t *g_inspector;
 extern game_t *g_game;
@@ -436,9 +434,9 @@ void draw_bsp(map_data_t const *map, viewdef_t const *viewdef);
 void update_player_position_with_sliding(map_data_t const *map, player_t *player,
                                          float move_x, float move_y);
 
-void fill_rect(uint32_t color, int x, int y, int w, int h);
-void draw_rect(int tex, int x, int y, int w, int h);
-void draw_rect_ex(int tex, int x, int y, int w, int h, int type, float alpha);
+void fill_rect(uint32_t color, rect_t const *r);
+void draw_rect(int tex, rect_t const *r);
+void draw_rect_ex(int tex, rect_t const *r, int type, float alpha);
 void draw_icon8(int icon, int x, int y, uint32_t col);
 void draw_icon16(int icon, int x, int y, uint32_t col);
 void draw_palette(map_data_t const *map);

--- a/mapview/map.h
+++ b/mapview/map.h
@@ -38,7 +38,6 @@ if ((map)->name) free((map)->name); \
 #define P_RADIUS 12.0f        // Player radius
 #define PALETTE_WIDTH 24
 #define NOTEX_SIZE 64
-#define SCROLL_SENSITIVITY 5
 #define SPRITE_SCALE 2
 #define SCALE_POINT(x) ((x)/2)
 #define HEXEN

--- a/mapview/texture.c
+++ b/mapview/texture.c
@@ -339,7 +339,7 @@ int allocate_mapside_textures(void) {
 //    maybe_load_texture(texture_cache, side->bottomtexture, tex_dirs, pnames);
 //  }
   
-  create_window("Textures", WINDOW_VSCROLL, MAKERECT(20, 20, 256, 256), NULL, win_textures, texture_cache);
+  create_window("Textures", WINDOW_VSCROLL, MAKERECT(20, 20, 256, 256), NULL, win_textures, 0, texture_cache);
   
   if (texture_cache->num_textures) {
     memcpy(texture_cache->selected, texture_cache->textures->name, sizeof(texname_t));
@@ -522,7 +522,7 @@ int allocate_flat_textures(void) {
 //    }
 //  }
   
-  create_window("Flats", WINDOW_VSCROLL, MAKERECT(ui_get_system_metrics(kSystemMetricScreenWidth)-148, 20, 128, 256), NULL, win_textures, flat_cache);
+  create_window("Flats", WINDOW_VSCROLL, MAKERECT(ui_get_system_metrics(kSystemMetricScreenWidth)-148, 20, 128, 256), NULL, win_textures, 0, flat_cache);
   
   if (flat_cache->num_textures) {
     memcpy(flat_cache->selected, flat_cache->textures->name, sizeof(texname_t));

--- a/mapview/wi_stuff.c
+++ b/mapview/wi_stuff.c
@@ -96,12 +96,11 @@ void handle_intermission_input(float delta_time) {
   ui_event_t event;
   while (axPollEvent(&event)) {
     if (event.message == kEventWindowClosed) {
-      extern bool running;
-      running = false;
+      g_ui_runtime.running = false;
     }
     switch (event.message) {
       case kEventMouseMoved:
-      case kEventLeftMouseDragged:
+      case kEventLeftButtonDragged:
         g_mouse_x = event.x;
         g_mouse_y = event.y;
         {
@@ -115,7 +114,7 @@ void handle_intermission_input(float delta_time) {
           }
         }
         break;
-      case kEventLeftMouseUp:
+      case kEventLeftButtonUp:
         if (selected >= 0) {
           char name[64]={0};
           snprintf(name, 64, "E1M%d", selected+1);


### PR DESCRIPTION
- Renamed all kWindowMessage* → ev* event constants (sed)
- Renamed kButton*, kComboBox*, kToolBar*, kScrollBar*, kStatusBar* → short forms
- Renamed kColor* → br* system color constants
- Updated fill_rect/draw_rect/draw_rect_ex to use rect_t* with R() macro
- Updated show_dialog signature to use int w, int h instead of rect_t*
- Removed toolbar_button_t; use toolbar_item_t with TOOLBAR_ITEM_BUTTON
- Replaced tbButtonClick active-loop with tbSetActiveButton send_message
- Removed extern _focused/_captured; use g_ui_runtime.focused/.captured
- Added hinstance_t argument to create_window calls (pass 0 or hinstance)
- Replaced main() with gem_init/gem_shutdown + GEM_STANDALONE_MAIN
- Fixed wi_stuff.c: kEventLeftMouseDragged/Up and running → g_ui_runtime.running
- Added ui/user/rect.h include to gamefont.c for R() macro